### PR TITLE
Connectors

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,13 @@
 
 ## pubsub
 
+### 2.1 (01-23-2016)
+
+ * **Breaking Change**: `ConnectionParam` has moved from the `pubsub` package to
+   the `conn` package.
+ * **Breaking Change**: `pubsub.New` no longer takes a `ConnectionParam`, rather
+   it takes a `*redis.Pool` and a `conn.ReconnectPolicy`.
+
 ### 2.0 (25-08-2015) rc
 
  * **Breaking Change**: New() now takes a ConnectionParam value rather than a pointer.

--- a/conn/conn.go
+++ b/conn/conn.go
@@ -1,0 +1,68 @@
+package conn
+
+import (
+	"time"
+
+	"github.com/garyburd/redigo/redis"
+)
+
+// Used to denote the parameters of the redis connection.
+type ConnectionParam struct {
+	// Host:port
+	Address string
+	// Optional password. Defaults to no authentication.
+	Password string
+	// Policy to use for reconnections (defaults to
+	// LogReconnectPolicy with a base of 10 and factor of 1 ms)
+	Policy ReconnectPolicy
+	// Dial timeout for redis (defaults to no timeout)
+	Timeout time.Duration
+}
+
+// New makes and returns a pointer to a new Connector instance. It sets some
+// defaults on the ConnectionParam object, such as the policy, which defaults to
+// a LogReconnectPolicy with a base of 10ms. A call to this function does not
+// produce a connection.
+func New(param ConnectionParam, maxIdle int) (*redis.Pool, ReconnectPolicy) {
+	if param.Policy == nil {
+		param.Policy = &LogReconnectPolicy{Base: 10, Factor: time.Millisecond}
+	}
+
+	return redis.NewPool(connect(param), maxIdle), param.Policy
+}
+
+// connect is a higher-order function that returns a function that dials,
+// connects, and authenticates a Redis connection.
+//
+// It attempts to dial a TCP connection to the address specified, timing out if
+// no connection was able to be established within the given time-frame. If no
+// timeout was given, it will wait indefinitely.
+//
+// If a password as specified in the ConnectionParam object, then an `AUTH`
+// command (see: http://redis.io/commands/auth) is issued with that password.
+//
+// If an error is incurred either dialing the TCP connection, or sending the
+// `AUTH` command, then it will be returned immediately, and the client can be
+// considered useless.
+func connect(param ConnectionParam) func() (redis.Conn, error) {
+	return func() (cnx redis.Conn, err error) {
+		if param.Timeout > 0 {
+			cnx, err = redis.DialTimeout("tcp", param.Address,
+				param.Timeout, param.Timeout, param.Timeout)
+		} else {
+			cnx, err = redis.Dial("tcp", param.Address)
+		}
+
+		if err != nil {
+			return
+		}
+
+		if param.Password != "" {
+			if _, err = cnx.Do("AUTH", param.Password); err != nil {
+				return
+			}
+		}
+
+		return
+	}
+}

--- a/conn/conn_test.go
+++ b/conn/conn_test.go
@@ -1,0 +1,31 @@
+package conn
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidConnections(t *testing.T) {
+	pool, _ := New(ConnectionParam{
+		Address: "127.0.0.1:6379",
+	}, 1)
+
+	cnx := pool.Get()
+	err := cnx.Err()
+
+	assert.NotNil(t, cnx)
+	assert.Nil(t, err)
+}
+
+func TestInvalidConnection(t *testing.T) {
+	pool, _ := New(ConnectionParam{
+		Address: "127.0.0.2:6379",
+		Timeout: 50 * time.Millisecond,
+	}, 1)
+
+	err := pool.Get().Err()
+
+	assert.Equal(t, "dial tcp 127.0.0.2:6379: i/o timeout", err.Error())
+}

--- a/conn/policy.go
+++ b/conn/policy.go
@@ -1,4 +1,4 @@
-package pubsub
+package conn
 
 import (
 	"math"

--- a/pubsub/client.go
+++ b/pubsub/client.go
@@ -161,6 +161,8 @@ func (c *Client) Connect() {
 
 func (c *Client) doConnection() {
 	cnx := c.pool.Get()
+	defer cnx.Close()
+
 	err := cnx.Err()
 
 	if err != nil {

--- a/pubsub/client.go
+++ b/pubsub/client.go
@@ -5,7 +5,9 @@
 //
 // Basic usage, prints any messages it gets in the "foobar" channel:
 //
-//  client := NewPubsub("127.0.0.1:6379")
+//  client := pubsub.New(conn.New(conn.ConnectionParam{
+//	Address: "127.0.0.1:6379"
+//  }, 1))
 //  defer client.TearDown()
 //  go client.Connect()
 //
@@ -35,21 +37,9 @@ import (
 	"time"
 
 	"github.com/WatchBeam/fsm"
+	"github.com/WatchBeam/redutil/conn"
 	"github.com/garyburd/redigo/redis"
 )
-
-// Used to denote the parameters of the redis connection.
-type ConnectionParam struct {
-	// Host:port
-	Address string
-	// Optional password. Defaults to no authentication.
-	Password string
-	// Policy to use for reconnections (defaults to
-	// LogReconnectPolicy with a base of 10 and factor of 1 ms)
-	Policy ReconnectPolicy
-	// Dial timeout for redis (defaults to no timeout)
-	Timeout time.Duration
-}
 
 // Used to denote the type of listener - channel or pattern.
 type ListenerType uint8
@@ -85,37 +75,30 @@ type Client struct {
 	// The current state that the client is in.
 	state     *fsm.Machine
 	stateLock *sync.Mutex
-	// Connection params we're subbed to.
-	conn ConnectionParam
+	// Connection we're subbed to.
+	pool *redis.Pool
 	// The subscription client we're currently using.
 	pubsub *redis.PubSubConn
 	// A list of events that we're subscribed to. If the connection closes,
 	// we'll reestablish it and resubscribe to events.
 	subscribed map[string][]*Listener
-	// Reconnection policy.
-	policy ReconnectPolicy
+	// Reconnection policy
+	policy conn.ReconnectPolicy
 	// Channel of sub/unsub tasks
 	tasks chan task
 }
 
 // Creates and returns a new pubsub client client and subscribes to it.
-func New(conn ConnectionParam) *Client {
-	client := &Client{
+func New(pool *redis.Pool, reconnectPolicy conn.ReconnectPolicy) *Client {
+	return &Client{
 		eventEmitter: newEventEmitter(),
 		state:        blueprint.Machine(),
 		stateLock:    new(sync.Mutex),
-		conn:         conn,
+		pool:         pool,
 		subscribed:   map[string][]*Listener{},
+		policy:       reconnectPolicy,
 		tasks:        make(chan task, 128),
 	}
-
-	if conn.Policy != nil {
-		client.policy = conn.Policy
-	} else {
-		client.policy = &LogReconnectPolicy{Base: 10, Factor: time.Millisecond}
-	}
-
-	return client
 }
 
 // Convenience function to create a new listener for an event.
@@ -177,25 +160,12 @@ func (c *Client) Connect() {
 }
 
 func (c *Client) doConnection() {
-	var cnx redis.Conn
-	var err error
-	if c.conn.Timeout > 0 {
-		cnx, err = redis.DialTimeout("tcp", c.conn.Address,
-			c.conn.Timeout, c.conn.Timeout, c.conn.Timeout)
-	} else {
-		cnx, err = redis.Dial("tcp", c.conn.Address)
-	}
+	cnx := c.pool.Get()
+	err := cnx.Err()
 
 	if err != nil {
 		c.emit(ErrorEvent, err)
 		return
-	}
-
-	if c.conn.Password != "" {
-		if _, err := cnx.Do("AUTH", c.conn.Password); err != nil {
-			c.emit(ErrorEvent, err)
-			c.setState(ClosingState)
-		}
 	}
 
 	c.pubsub = &redis.PubSubConn{Conn: cnx}

--- a/pubsub/pubsub_test.go
+++ b/pubsub/pubsub_test.go
@@ -2,10 +2,12 @@ package pubsub
 
 import (
 	"fmt"
-	"github.com/garyburd/redigo/redis"
-	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
+
+	"github.com/WatchBeam/redutil/conn"
+	"github.com/garyburd/redigo/redis"
+	"github.com/stretchr/testify/assert"
 )
 
 func publish(event string, data string) {
@@ -20,10 +22,10 @@ func disrupt(client *Client) {
 }
 
 func create(t *testing.T) *Client {
-	client := New(ConnectionParam{
+	client := New(conn.New(conn.ConnectionParam{
 		Address: "127.0.0.1:6379",
 		Timeout: time.Second,
-	})
+	}, 1))
 	go client.Connect()
 	client.WaitFor(ConnectedEvent)
 

--- a/readme.md
+++ b/readme.md
@@ -14,17 +14,18 @@ package main
 
 import (
     "time"
-    "github.com/mcprohosting/redutil/pubsub"
+    "github.com/WatchBeam/redutil/conn"
+    "github.com/WatchBeam/redutil/pubsub"
 )
 
 func main() {
     // Create a new pubsub client. This will create and manage connections,
     // even if you disconnect.
-    c := pubsub.New(pubsub.ConnectionParam{
+    c := pubsub.New(conn.New(conn.ConnectionParam{
         Address: "127.0.0.1:6379",
         // optional password
         Password: "secret",
-    })
+    }, 1))
     go client.Connect()
     defer c.TearDown()
 
@@ -60,4 +61,4 @@ func listenPattern(c *pubsub.Client) {
 
 ## License
 
-Copyright 2015 by Beam LLC. Distributed under the MIT license.
+Copyright 2015-2016 by Beam LLC. Distributed under the MIT license.


### PR DESCRIPTION
Since we're going to need Redis connections in several packages now, I figured it makes sense to extract this connection-producing logic out.

This PR introduces the `conn` package, which is essentially responsible for taking a `ConnectionParam` and turning it into a `*redis.Pool`. The created `*redis.Pool` also handles sending the `AUTH` packet; something we need to do to maintain our contract with the `Password` parameter.

The `CHANGELOG` has been updated with all breaking changes.

------------------------

Since Travis seems to only go green intermittently:

```
ttaylorr@taylor-mbpro redutil (feature/connector) $ go test ./conn/ ./pubsub/
ok  	github.com/WatchBeam/redutil/conn	0.062s
ok  	github.com/WatchBeam/redutil/pubsub	0.452s
```

------------------------
/to @connor4312 