### PR TITLE
Add queue concat methods

### DIFF
--- a/queue/byte_queue.go
+++ b/queue/byte_queue.go
@@ -6,6 +6,10 @@ import (
 	"github.com/garyburd/redigo/redis"
 )
 
+// The number of errors we can get while concatting in a row before giving
+// up and just returning.
+const concatRetries int = 3
+
 // ByteQueue represents either a FILO or FIFO queue contained in a particular
 // Redis keyspace. It allows callers to push `[]byte` payloads, and receive them
 // back over the `In() <-chan []byte`. It is typically used in a distributed
@@ -80,6 +84,46 @@ func (b *ByteQueue) Push(payload []byte) error {
 	}
 
 	return nil
+}
+
+// Takes all elements from the source queue and adds them to this one. This
+// can be a long-running operation. If a persistent error is returned while
+// moving things, then it will be returned and the concat will stop, though
+// the concat operation can be safely resumed at any time.
+func (b *ByteQueue) Concat(src string) error {
+	cnx := b.pool.Get()
+	defer cnx.Close()
+
+	var err error
+	errCount := 0
+	for {
+		err = b.Processor().Concat(cnx, src, b.name)
+		if err == nil {
+			errCount = 0
+			continue
+		}
+
+		// ErrNil is returned when there are no more items to concat
+		if err == redis.ErrNil {
+			return nil
+		}
+
+		// Command error are bad; something is wrong in db and we should
+		// return the problem to the caller.
+		if _, cmdErr := err.(redis.Error); cmdErr {
+			return err
+		}
+
+		// Otherwise this is probably some temporary network error. Close
+		// the old connection and try getting a new one.
+		errCount++
+		if errCount >= concatRetries {
+			return err
+		}
+
+		cnx.Close()
+		cnx = b.pool.Get()
+	}
 }
 
 // Processor returns the processor that is being used to push and pull. If no

--- a/queue/byte_queue_test.go
+++ b/queue/byte_queue_test.go
@@ -96,7 +96,7 @@ func (suite *ByteQueueSuite) TestPullDelegatesToProcessor() {
 	suite.Assert().Equal([]byte("bar"), <-q.In())
 }
 
-func (suite *ByteQueueSuite) TestConcatsSuccessfully() {
+func (suite *ByteQueueSuite) TestConcatsDelegatesToProcessor() {
 	processor := &MockProcessor{}
 	processor.On("Concat",
 		mock.Anything, "bar", "foo").

--- a/queue/fifo_processor.go
+++ b/queue/fifo_processor.go
@@ -11,7 +11,7 @@ var FIFO Processor = &fifoProcessor{}
 // of the Redis structure using RPUSH, and returns any errors encountered while
 // runnning that command.
 func (l *fifoProcessor) Push(cnx redis.Conn, key string, payload []byte) (err error) {
-	_, err = cnx.Do("RPUSH", key, payload)
+	_, err = cnx.Do("LPUSH", key, payload)
 	return
 }
 
@@ -26,7 +26,7 @@ func (l *fifoProcessor) Push(cnx redis.Conn, key string, payload []byte) (err er
 // If an item can sucessfully be removed from the keyspace, it is returned
 // without error.
 func (l *fifoProcessor) Pull(cnx redis.Conn, key string) ([]byte, error) {
-	slices, err := redis.ByteSlices(cnx.Do("BLPOP", key, 1))
+	slices, err := redis.ByteSlices(cnx.Do("BRPOP", key, 1))
 	if err == redis.ErrNil {
 		return nil, nil
 	}
@@ -36,4 +36,10 @@ func (l *fifoProcessor) Pull(cnx redis.Conn, key string) ([]byte, error) {
 	}
 
 	return slices[1], nil
+}
+
+// Removes the first element from the source list and adds it to the end
+// of the destination list. ErrNil is returns when the source is empty.
+func (f *fifoProcessor) Concat(cnx redis.Conn, src, dest string) (err error) {
+	return rlConcat(cnx, src, dest)
 }

--- a/queue/fifo_processor_test.go
+++ b/queue/fifo_processor_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/WatchBeam/redutil/conn"
 	"github.com/WatchBeam/redutil/queue"
 	"github.com/WatchBeam/redutil/test"
+	"github.com/garyburd/redigo/redis"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -21,6 +22,15 @@ func TestFIFOProcessorSuite(t *testing.T) {
 	suite.Run(t, &FIFOProcessorTest{test.NewSuite(pool)})
 }
 
+func (suite *FIFOProcessorTest) assertOrder(cnx redis.Conn) {
+	first, _ := queue.FIFO.Pull(cnx, "keyspace")
+	second, _ := queue.FIFO.Pull(cnx, "keyspace")
+	third, _ := queue.FIFO.Pull(cnx, "keyspace")
+	suite.Assert().Equal([]byte("first"), first)
+	suite.Assert().Equal([]byte("second"), second)
+	suite.Assert().Equal([]byte("third"), third)
+}
+
 func (suite *FIFOProcessorTest) TestProcessingOrder() {
 	cnx := suite.Pool.Get()
 	defer cnx.Close()
@@ -29,10 +39,20 @@ func (suite *FIFOProcessorTest) TestProcessingOrder() {
 	queue.FIFO.Push(cnx, "keyspace", []byte("second"))
 	queue.FIFO.Push(cnx, "keyspace", []byte("third"))
 
-	first, _ := queue.FIFO.Pull(cnx, "keyspace")
-	second, _ := queue.FIFO.Pull(cnx, "keyspace")
-	third, _ := queue.FIFO.Pull(cnx, "keyspace")
-	suite.Assert().Equal([]byte("first"), first)
-	suite.Assert().Equal([]byte("second"), second)
-	suite.Assert().Equal([]byte("third"), third)
+	suite.assertOrder(cnx)
+}
+
+func (suite *FIFOProcessorTest) TestConcats() {
+	cnx := suite.Pool.Get()
+	defer cnx.Close()
+
+	queue.FIFO.Push(cnx, "keyspace", []byte("first"))
+	queue.FIFO.Push(cnx, "keyspace2", []byte("second"))
+	queue.FIFO.Push(cnx, "keyspace2", []byte("third"))
+
+	suite.Assert().Nil(queue.FIFO.Concat(cnx, "keyspace2", "keyspace"))
+	suite.Assert().Nil(queue.FIFO.Concat(cnx, "keyspace2", "keyspace"))
+	suite.Assert().Equal(redis.ErrNil, queue.FIFO.Concat(cnx, "keyspace2", "keyspace"))
+
+	suite.assertOrder(cnx)
 }

--- a/queue/lifo_processor.go
+++ b/queue/lifo_processor.go
@@ -37,3 +37,9 @@ func (l *lifoProcessor) Pull(cnx redis.Conn, key string) ([]byte, error) {
 
 	return slices[1], nil
 }
+
+// Removes the first element from the source list and adds it to the end
+// of the destination list. ErrNil is returns when the source is empty.
+func (l *lifoProcessor) Concat(cnx redis.Conn, src, dest string) (err error) {
+	return rlConcat(cnx, src, dest)
+}

--- a/queue/lifo_processor_test.go
+++ b/queue/lifo_processor_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/WatchBeam/redutil/conn"
 	"github.com/WatchBeam/redutil/queue"
 	"github.com/WatchBeam/redutil/test"
+	"github.com/garyburd/redigo/redis"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -21,6 +22,15 @@ func TestLIFOProcessorSuite(t *testing.T) {
 	suite.Run(t, &LIFOProcessorTest{test.NewSuite(pool)})
 }
 
+func (suite *LIFOProcessorTest) assertOrder(cnx redis.Conn) {
+	first, _ := queue.LIFO.Pull(cnx, "keyspace")
+	second, _ := queue.LIFO.Pull(cnx, "keyspace")
+	third, _ := queue.LIFO.Pull(cnx, "keyspace")
+	suite.Assert().Equal([]byte("third"), first)
+	suite.Assert().Equal([]byte("second"), second)
+	suite.Assert().Equal([]byte("first"), third)
+}
+
 func (suite *LIFOProcessorTest) TestProcessingOrder() {
 	cnx := suite.Pool.Get()
 	defer cnx.Close()
@@ -29,10 +39,20 @@ func (suite *LIFOProcessorTest) TestProcessingOrder() {
 	queue.LIFO.Push(cnx, "keyspace", []byte("second"))
 	queue.LIFO.Push(cnx, "keyspace", []byte("third"))
 
-	first, _ := queue.LIFO.Pull(cnx, "keyspace")
-	second, _ := queue.LIFO.Pull(cnx, "keyspace")
-	third, _ := queue.LIFO.Pull(cnx, "keyspace")
-	suite.Assert().Equal([]byte("third"), first)
-	suite.Assert().Equal([]byte("second"), second)
-	suite.Assert().Equal([]byte("first"), third)
+	suite.assertOrder(cnx)
+}
+
+func (suite *LIFOProcessorTest) TestConcats() {
+	cnx := suite.Pool.Get()
+	defer cnx.Close()
+
+	queue.LIFO.Push(cnx, "keyspace", []byte("first"))
+	queue.LIFO.Push(cnx, "keyspace2", []byte("second"))
+	queue.LIFO.Push(cnx, "keyspace2", []byte("third"))
+
+	suite.Assert().Nil(queue.LIFO.Concat(cnx, "keyspace2", "keyspace"))
+	suite.Assert().Nil(queue.LIFO.Concat(cnx, "keyspace2", "keyspace"))
+	suite.Assert().Equal(redis.ErrNil, queue.LIFO.Concat(cnx, "keyspace2", "keyspace"))
+
+	suite.assertOrder(cnx)
 }

--- a/queue/processor.go
+++ b/queue/processor.go
@@ -12,6 +12,10 @@ type Processor interface {
 
 	// Pull pulls a given `payload` from the keyspace at `key` over the
 	// given `redis.Conn`. This function should block until a timeout has
-	// elapsed.
+	// elapsed, or an item is available.
 	Pull(conn redis.Conn, key string) (payload []byte, err error)
+
+	// Moves all elements from the src queue to the end of the destination
+	// It should return a redis.ErrNil when the source queue is empty.
+	Concat(conn redis.Conn, src, dest string) (err error)
 }

--- a/queue/util.go
+++ b/queue/util.go
@@ -1,0 +1,17 @@
+package queue
+
+import "github.com/garyburd/redigo/redis"
+
+// Concat implementation using RPOPLPUSH, compatible
+// with the behaviour of Processor.Queue.
+func rlConcat(cnx redis.Conn, src, dest string) error {
+	data, err := cnx.Do("RPOPLPUSH", src, dest)
+	if err != nil {
+		return err
+	}
+	if data == nil {
+		return redis.ErrNil
+	}
+
+	return nil
+}


### PR DESCRIPTION
Adds simple queue concat methods. In both LIFO and FIFO, concat will append the items in the source queue to be processed after the ones in the destination queue.