### PR TITLE
worker/task: add convenience HexDump() and String() methods

### DIFF
--- a/worker/task.go
+++ b/worker/task.go
@@ -68,7 +68,7 @@ func (t *Task) HexDump() string {
 	return hex.Dump(t.Bytes())
 }
 
-// String returns a dump of the task contents as a string.
+// String returns the strinigified contents of the task payload.
 func (t *Task) String() string {
 	return string(t.Bytes())
 }

--- a/worker/task.go
+++ b/worker/task.go
@@ -1,6 +1,7 @@
 package worker
 
 import (
+	"encoding/hex"
 	"errors"
 	"sync"
 )
@@ -59,6 +60,17 @@ func (t *Task) IsResolved() bool {
 	defer t.resolvedMu.Unlock()
 
 	return t.resolved
+}
+
+// HexDump returns a byte dump of the task, in the same format as `hexdump -C`.
+// This is useful for debugging/logging purposes.
+func (t *Task) HexDump() string {
+	return hex.Dump(t.Bytes())
+}
+
+// String returns a dump of the task contents as a string.
+func (t *Task) String() string {
+	return string(t.Bytes())
 }
 
 // guardResolution runs the inner fn only if the task is not already resolved,

--- a/worker/task_test.go
+++ b/worker/task_test.go
@@ -36,6 +36,17 @@ func (suite *TaskSuite) TestBytesReturnsPayload() {
 	suite.Assert().Equal([]byte("hello world"), payload)
 }
 
+func (suite *TaskSuite) TestDumpsBody() {
+	task := worker.NewTask(&MockLifecycle{}, []byte("hello world"))
+	expected := "00000000  68 65 6c 6c 6f 20 77 6f  72 6c 64                 |hello world|\n"
+	suite.Assert().Equal(expected, task.HexDump())
+}
+
+func (suite *TaskSuite) TestStringReturns() {
+	task := worker.NewTask(&MockLifecycle{}, []byte("hello world"))
+	suite.Assert().Equal("hello world", task.String())
+}
+
 func (suite *TaskSuite) TestSucceedingDelegatesToLifecycle() {
 	lifecycle := &MockLifecycle{}
 	lifecycle.On("Complete", mock.Anything).Return(nil)


### PR DESCRIPTION
Being able to dump the hex/string content of a message is quite useful for debugging/logging.