### PR TITLE
heartbeat/simple_heart: touch the strategy immediately on boot

### DIFF
--- a/heartbeat/simple_heart_test.go
+++ b/heartbeat/simple_heart_test.go
@@ -38,11 +38,12 @@ func (suite *SimpleHeartbeatSuite) TestStrategyIsCalledAtInterval() {
 	strategy.On("Touch", "foo", "bar", suite.Pool).Return(nil)
 
 	h := heartbeat.NewSimpleHeart("bar", "foo", 5*time.Millisecond, suite.Pool, strategy)
+	strategy.AssertNumberOfCalls(suite.T(), "Touch", 1)
 	defer h.Close()
 
 	time.Sleep(10 * time.Millisecond)
 
-	strategy.AssertNumberOfCalls(suite.T(), "Touch", 1)
+	strategy.AssertNumberOfCalls(suite.T(), "Touch", 2)
 }
 
 func (suite *SimpleHeartbeatSuite) TestStrategyPropogatesErrors() {
@@ -53,8 +54,9 @@ func (suite *SimpleHeartbeatSuite) TestStrategyPropogatesErrors() {
 	defer h.Close()
 
 	errs := h.Errs()
+	suite.Assert().Len(errs, 1)
 
-	suite.Assert().Len(errs, 0)
+	<-errs
 
 	time.Sleep(150 * time.Millisecond)
 
@@ -71,5 +73,5 @@ func (suite *SimpleHeartbeatSuite) TestCloseStopsCallingStrategy() {
 
 	time.Sleep(10 * time.Millisecond)
 
-	strategy.AssertNumberOfCalls(suite.T(), "Touch", 0)
+	strategy.AssertNumberOfCalls(suite.T(), "Touch", 1)
 }


### PR DESCRIPTION
I noticed this when MONITORing some stuff on Notifyd today. Previously the
strategy would only insert the key after the interval had passed. This meant
that if the daemon crashed in that period of time, any items it read
from the queue would be irretreivably lost. This PR modifies the heart
beat so that it touches the hash once before returning. This'll cause
workers to exist in that hash before they start clamoring for queue
items.