### PR TITLE
Add a convenience ListenerFunc method

### DIFF
--- a/pubsub2/emitter.go
+++ b/pubsub2/emitter.go
@@ -51,12 +51,10 @@ type Listener interface {
 	Handle(e Event, b []byte)
 }
 
-type listenerFunc struct{ handle func(e Event, b []byte) }
+// ListenerFunc is a Listener implementation which invokes itself when Handle is called.
+type ListenerFunc func(e Event, b []byte)
 
-func (l listenerFunc) Handle(e Event, b []byte) { l.handle(e, b) }
-
-// ListenerFunc creates a Listener which invokes the provided function.
-func ListenerFunc(fn func(e Event, b []byte)) Listener { return &listenerFunc{fn} }
+func (l ListenerFunc) Handle(e Event, b []byte) { l(e, b) }
 
 // Emitter is the primary interface to interact with pubsub.
 type Emitter interface {

--- a/pubsub2/emitter.go
+++ b/pubsub2/emitter.go
@@ -51,6 +51,13 @@ type Listener interface {
 	Handle(e Event, b []byte)
 }
 
+type listenerFunc struct{ handle func(e Event, b []byte) }
+
+func (l listenerFunc) Handle(e Event, b []byte) { l.handle(e, b) }
+
+// ListenerFunc creates a Listener which invokes the provided function.
+func ListenerFunc(fn func(e Event, b []byte)) Listener { return &listenerFunc{fn} }
+
 // Emitter is the primary interface to interact with pubsub.
 type Emitter interface {
 	// Subscribe registers that the provided lister wants to be notified

--- a/pubsub2/emitter_test.go
+++ b/pubsub2/emitter_test.go
@@ -1,0 +1,20 @@
+package pubsub
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestListenerFunc(t *testing.T) {
+	called := false
+	fn := func(e Event, b []byte) {
+		assert.Equal(t, "foo", e.Channel())
+		assert.Equal(t, []byte{1, 2, 3}, b)
+		called = true
+	}
+
+	listener := ListenerFunc(fn)
+	listener.Handle(NewEvent().String("foo").ToEvent("foo", "foo"), []byte{1, 2, 3})
+	assert.True(t, called)
+}


### PR DESCRIPTION
Wraps a handler function into a type that can be passed as a Listener to Emitter.Subscribe. Similar to http.HandlerFunc.